### PR TITLE
Improve error messages when set_priority fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn set_max_priority() {
         let result = sched_setscheduler(0, SCHED_FIFO, &param);
 
         if result != 0 {
-            panic!("errno");
+            panic!("Error setting priority, you may not have cap_sys_nice capability");
         }
     }
 }
@@ -85,7 +85,7 @@ fn set_default_priority() {
         let result = sched_setscheduler(0, SCHED_OTHER, &param);
 
         if result != 0 {
-            panic!("errno");
+            panic!("Error setting priority, you may not have cap_sys_nice capability");
         }
     }
 }


### PR DESCRIPTION
I encountered this issue when trying to use this library. It took a lot of googling to find [the solution](https://stackoverflow.com/questions/7635515/how-to-set-cap-sys-nice-capability-to-a-linux-user). This might get people on the right track faster.