### PR TITLE
Updated dependencies versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["pi", "dht22", "temperature"]
 edition = "2018"
 
 [dependencies]
-rppal = "0.11.3"
-libc = "0.2.21"
+rppal = { version = "0.13.1" }
+libc =  { version = "0.2.126" }


### PR DESCRIPTION
Updated dependencies to latest versions:
- `rppal v0.13.1` (fixes https://github.com/golemparts/rppal/issues/73)
- `libc v0.2.126`